### PR TITLE
change range to 180 days

### DIFF
--- a/crashstop/datacollector.py
+++ b/crashstop/datacollector.py
@@ -61,7 +61,7 @@ def get_filter_query(fa_bids, fx_bids, channel):
     min_bid = min(min_bid, fx_bids[0][0]) if fx_bids else min_bid
     date = max(
         utils.get_build_date(min_bid),
-        lmdutils.get_date_ymd('today') - relativedelta(days=364),
+        lmdutils.get_date_ymd('today') - relativedelta(days=180),
     )
     date = date.strftime('%Y-%m-%d')
     if channel == 'beta':


### PR DESCRIPTION
Socorro only stores 180 days worth of crash reports. Best to reduce the asking range to that.